### PR TITLE
Normalize size key like in official adapters

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -13,7 +13,7 @@ class DropboxAdapter extends AbstractAdapter
 {
     use NotSupportingVisibilityTrait;
 
-    /** @var \Spatie\FlysystemDropbox\DropboxClient */
+    /** @var \Spatie\Dropbox\Client */
     protected $client;
 
     public function __construct(Client $client, string $prefix = '')
@@ -285,6 +285,7 @@ class DropboxAdapter extends AbstractAdapter
         }
 
         if (isset($response['size'])) {
+            $normalizedResponse['size'] = $response['size'];
             $normalizedResponse['bytes'] = $response['size'];
         }
 


### PR DESCRIPTION
Official adapters use "size" key, not "bytes" key.

So I've changed the key to "size" :)

See: https://github.com/thephpleague/flysystem/blob/master/src/Adapter/Local.php#L493