### PR TITLE
Traverse multiple pages when listing contents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.0",
         "league/flysystem": "^1.0",
-        "spatie/dropbox-api": "^1.0"
+        "spatie/dropbox-api": "^1.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -177,8 +177,14 @@ class DropboxAdapter extends AbstractAdapter
         $location = $this->applyPathPrefix($directory);
 
         $result = $this->client->listFolder($location, $recursive);
+        $entries = $result['entries'];
 
-        if (! count($result['entries'])) {
+        while ($result['has_more']) {
+            $result = $this->client->listFolderContinue($result['cursor']);
+            $entries = array_merge($entries, $result['entries']);
+        }
+
+        if (! count($entries)) {
             return [];
         }
 
@@ -186,7 +192,7 @@ class DropboxAdapter extends AbstractAdapter
             $path = $this->removePathPrefix($entry['path_display']);
 
             return $this->normalizeResponse($entry, $path);
-        }, $result['entries']);
+        }, $entries);
     }
 
     /**


### PR DESCRIPTION
Re: #26 - Allows `DropboxAdapter::listContents()` to get entries from multiple pages of results.