### PR TITLE
List files exception

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -176,7 +176,12 @@ class DropboxAdapter extends AbstractAdapter
     {
         $location = $this->applyPathPrefix($directory);
 
-        $result = $this->client->listFolder($location, $recursive);
+        try {
+            $result = $this->client->listFolder($location, $recursive);
+        } catch (BadRequest $e) {
+            return [];
+        }
+
         $entries = $result['entries'];
 
         while ($result['has_more']) {


### PR DESCRIPTION
I was using Laravel Backup to save my backup into a dropbox account. When calling `backup:list` before running any backup an exception was thrown: 
```
[Spatie\Dropbox\Exceptions\BadRequest]  
  path/not_found/...
```

It turn out Dropbox is returning an error when listing files in a directory that doesn't exists. 

Flysystem follows a [Files First](http://flysystem.thephpleague.com/core-concepts/#files-first) approach, and testing out using other drivers results in an empty array:
```
>>> Storage::disk('local')->allFiles('directory_not_found')
=> []
>>> Storage::disk('dropbox')->allFiles('directory_not_found')
Spatie\Dropbox\Exceptions\BadRequest with message 'path/not_found/'
```

This PR wraps dropbox call in a try-catch returning an empty array if `BadRequest` is thrown.

Reading dropbox documentation the only available error using this command is [path LookupError](https://www.dropbox.com/developers/documentation/http/documentation#files-list_folder), so there're only two possible errors here: `not_found`, `not_folder`.

I checked the behavior of the local driver when "listing files" given an existing file as path instead of a folder, it returns and empty array. So I assume catching all dropbox errors is consistent with Flysystem behavior.