### PR TITLE
Workaround for case issue Dropbox.

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -285,9 +285,13 @@ class DropboxAdapter extends AbstractAdapter
 
     protected function normalizeResponse(array $response): array
     {
-        $normalizedPath = ltrim($this->removePathPrefix($response['path_display']), '/');
+        $normalizedPath = ltrim($this->removePathPrefix($response['path_lower']), '/');
 
-        $normalizedResponse = ['path' => $normalizedPath];
+        $normalizedResponse = [
+            'path' => $normalizedPath,
+            'path_display' => ltrim($this->removePathPrefix($response['path_display']), '/'),
+            'name' => $response['name'],
+        ];
 
         if (isset($response['server_modified'])) {
             $normalizedResponse['timestamp'] = strtotime($response['server_modified']);

--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -194,9 +194,7 @@ class DropboxAdapter extends AbstractAdapter
         }
 
         return array_map(function ($entry) {
-            $path = $this->removePathPrefix($entry['path_display']);
-
-            return $this->normalizeResponse($entry, $path);
+            return $this->normalizeResponse($entry);
         }, $entries);
     }
 


### PR DESCRIPTION
This is a workaround for https://www.dropboxforum.com/t5/API-Support-Feedback/APIV1-ListDirectory-lowercase-issue/td-p/210931

Sometimes Dropbox API returns the lowercase path in the path_display of all files and directories in a response. Because the check at \League\Flysystem\Util\ContentListingFormatter::isDirectChild is case sensitive it won't return those files or dirs.

This pr will always return the lowercase path (path_lower) as value of the path key, but will also include the path_display (which is inconsistently lowercase or uppercase) and the name (which has always the correct casing) of the dropbox result respectively as the value of the path_display key and the name key.

This pr is a breaking change in my opinion because it now expects the dev to always pass the lowercase path as the directory argument of the Filesystem::listContents method.