### PR TITLE
Add 'case_sensitive' option and explanation in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ $client = new Client($authorizationToken);
 
 $adapter = new DropboxAdapter($client);
 
-$filesystem = new Filesystem($adapter);
+$filesystem = new Filesystem($adapter, ['case_sensitive' => false]);
 ```
+Note: Because Dropbox is not case-sensitive you’ll need to set the 'case_sensitive' option to false.
 
 ## Changelog
 


### PR DESCRIPTION
As documented on the [flysystem docs page](https://flysystem.thephpleague.com/docs/adapter/dropbox/), the 'case_sensitive' option needs to be set on the adapter.

Caught me out today, with `listContents` returning no results even though files existed.