### PR TITLE
fix league/flysystem minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "league/flysystem": "^1.0",
+        "league/flysystem": "^1.0.20",
         "spatie/dropbox-api": "^1.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
`MimeType::detectByFilename($path)` was first added in v1.0.20
https://github.com/spatie/flysystem-dropbox/blob/762cb0386def2b534db237d2267dfe8fd359d1ba/src/DropboxAdapter.php#L230-L233
https://github.com/thephpleague/flysystem/commit/15dcc8ee9b279b40fbcca47ad9c7257a41b61947