### PR TITLE
Make the createSharedLinkWithSettings method get the createSharedLinkWithSettings from the client parameter

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -262,7 +262,7 @@ class DropboxAdapter extends AbstractAdapter
 
     public function createSharedLinkWithSettings($path, $settings)
     {
-        return $this->createSharedLinkWithSettings($path, $settings);
+        return $this->client->createSharedLinkWithSettings($path, $settings);
     }
 
     /**


### PR DESCRIPTION
Before this change the method was an infinite loop and crashed the application every time that was called with memory limit exceed.