### PR TITLE
Add Support for Flysystem 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ composer require spatie/flysystem-dropbox
 
 The first thing you need to do is get an authorization token at Dropbox. A token can be generated in the [App Console](https://www.dropbox.com/developers/apps) for any Dropbox API app. You'll find more info at [the Dropbox Developer Blog](https://blogs.dropbox.com/developers/2014/05/generate-an-access-token-for-your-own-account/).
 
-``` php
+```php
 use League\Flysystem\Filesystem;
 use Spatie\Dropbox\Client;
 use Spatie\FlysystemDropbox\DropboxAdapter;
@@ -43,6 +43,7 @@ $adapter = new DropboxAdapter($client);
 
 $filesystem = new Filesystem($adapter, ['case_sensitive' => false]);
 ```
+
 Note: Because Dropbox is not case-sensitive you’ll need to set the 'case_sensitive' option to false.
 
 ## Changelog

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": "^7.0 || ^8.0",
-        "league/flysystem": "^1.0.20",
+        "php": ">7.2 || ^8.0",
+        "league/flysystem": "^2.0",
         "spatie/dropbox-api": "^1.1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "spatie/dropbox-api": "^1.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.11 || ^9.4.3"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.4.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -85,13 +85,13 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
             throw Flysystem\UnableToReadFile::fromLocation($path);
         }
 
-        $contents = stream_get_contents($object['stream']);
-        fclose($object['stream']);
-        unset($object['stream']);
-
-        if ($contents === false) {
+        if (!is_resource($object)) {
             throw Flysystem\UnableToReadFile::fromLocation($path);
         }
+
+        $contents = stream_get_contents($object);
+        fclose($object);
+        unset($object);
 
         return $contents;
     }

--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -3,8 +3,6 @@
 namespace Spatie\FlysystemDropbox;
 
 use League\Flysystem;
-use League\Flysystem\Config;
-use League\Flysystem\FileAttributes;
 use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use League\MimeTypeDetection\MimeTypeDetector;
 use Spatie\Dropbox\Client;
@@ -163,18 +161,18 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     /**
      * @inheritDoc
      */
-    public function visibility(string $path): FileAttributes
+    public function visibility(string $path): Flysystem\FileAttributes
     {
         // Noop
-        return new FileAttributes($path);
+        return new Flysystem\FileAttributes($path);
     }
 
     /**
      * @inheritDoc
      */
-    public function mimeType(string $path): FileAttributes
+    public function mimeType(string $path): Flysystem\FileAttributes
     {
-        return new FileAttributes(
+        return new Flysystem\FileAttributes(
             $path,
             null,
             null,
@@ -186,7 +184,7 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     /**
      * @inheritDoc
      */
-    public function lastModified(string $path): FileAttributes
+    public function lastModified(string $path): Flysystem\FileAttributes
     {
         $location = $this->applyPathPrefix($path);
 
@@ -198,7 +196,7 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
 
         $timestamp = (isset($response['server_modified'])) ? strtotime($response['server_modified']) : null;
 
-        return new FileAttributes(
+        return new Flysystem\FileAttributes(
             $path,
             null,
             null,
@@ -209,7 +207,7 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     /**
      * @inheritDoc
      */
-    public function fileSize(string $path): FileAttributes
+    public function fileSize(string $path): Flysystem\FileAttributes
     {
         $location = $this->applyPathPrefix($path);
 
@@ -219,7 +217,7 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
             throw Flysystem\UnableToRetrieveMetadata::lastModified($location, $e->getMessage());
         }
 
-        return new FileAttributes(
+        return new Flysystem\FileAttributes(
             $path,
             $response['size'] ?? null
         );
@@ -281,7 +279,7 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     /**
      * @inheritDoc
      */
-    public function move(string $source, string $destination, Config $config): void
+    public function move(string $source, string $destination, Flysystem\Config $config): void
     {
         $path = $this->applyPathPrefix($source);
         $newPath = $this->applyPathPrefix($destination);
@@ -296,7 +294,7 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     /**
      * @inheritDoc
      */
-    public function copy(string $source, string $destination, Config $config): void
+    public function copy(string $source, string $destination, Flysystem\Config $config): void
     {
         $path = $this->applyPathPrefix($source);
         $newPath = $this->applyPathPrefix($destination);


### PR DESCRIPTION
This PR adds support for the 2.x branch of Flysystem, which is not backwards-compatible with 1.x libraries.

The test suites have been updated both to ensure the tests are still accurate and to ensure the tests are modernized (built against a newer PHPUnit standard).

PHP compatibility is limited to PHP 7.2 or greater, which is in keeping with Flysystem 2.x itself.