### PR TITLE
Make listing a non-created directory not throw an exception.

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -246,9 +246,13 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     protected function iterateFolderContents(string $path = '', bool $deep = false): \Generator
     {
         $location = $this->applyPathPrefix($path);
-
-        $result = $this->client->listFolder($location, $deep);
-
+        
+        try {
+            $result = $this->client->listFolder($location, $deep);
+        } catch (BadRequest $e) {
+            return;
+        }
+        
         yield from $result['entries'];
 
         while ($result['has_more']) {


### PR DESCRIPTION
For other adapters, if you list a directory that wasn't already created, the `listContents` call will simply return nothing; currently the Dropbox adapter throws a "not found" exception in this case, which (even though it makes sense in this context) makes its behavior at odds with the other adapters.

This PR just catches that exception and halts the generator early instead.