### PR TITLE
Avoid listing the base directory itself in listContents calls.

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -239,7 +239,14 @@ class DropboxAdapter implements Flysystem\FilesystemAdapter
     public function listContents(string $path = '', bool $deep = false): iterable
     {
         foreach ($this->iterateFolderContents($path, $deep) as $entry) {
-            yield $this->normalizeResponse($entry);
+            $storageAttrs = $this->normalizeResponse($entry);
+
+            // Avoid including the base directory itself
+            if ($storageAttrs->isDir() && $storageAttrs->path() === $path) {
+                continue;
+            }
+
+            yield $storageAttrs;
         }
     }
 

--- a/tests/DropboxAdapterTest.php
+++ b/tests/DropboxAdapterTest.php
@@ -157,8 +157,9 @@ class DropboxAdapterTest extends TestCase
         $this->client->listFolder(Argument::type('string'), Argument::any())->willReturn(
             [
                 'entries' => [
-                    ['.tag' => 'folder', 'path_display' => 'dirname'],
-                    ['.tag' => 'file', 'path_display' => 'dirname/file'],
+                    // This is the prefixed folder itself and shouldn't be shown.
+                    ['.tag' => 'folder', 'path_display' => '/prefix'],
+                    ['.tag' => 'file', 'path_display' => '/prefix/file'],
                 ],
                 'has_more' => true,
                 'cursor' => $cursor,
@@ -168,15 +169,15 @@ class DropboxAdapterTest extends TestCase
         $this->client->listFolderContinue(Argument::exact($cursor))->willReturn(
             [
                 'entries' => [
-                    ['.tag' => 'folder', 'path_display' => 'dirname2'],
-                    ['.tag' => 'file', 'path_display' => 'dirname2/file2'],
+                    ['.tag' => 'folder', 'path_display' => '/prefix/dirname2'],
+                    ['.tag' => 'file', 'path_display' => '/prefix/dirname2/file2'],
                 ],
                 'has_more' => false,
             ]
         );
 
         $result = $this->dropboxAdapter->listContents('', true);
-        $this->assertCount(4, $result);
+        $this->assertCount(3, $result);
     }
 
     /** @test */


### PR DESCRIPTION
Another minor fix that brings this adapter in line with the other Flysystem adapters by ensuring that, when calling `listContents`, the base directory itself isn't included in the results, which it otherwise would be without this little safety check.