### PR TITLE
Changed visibility getter to throw instead of returning an "empty" FileAttributes instance

### DIFF
--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -196,12 +196,17 @@ class DropboxAdapter implements FilesystemAdapter, ChecksumProvider
      */
     public function mimeType(string $path): FileAttributes
     {
+        $mimeType = $this->mimeTypeDetector->detectMimeTypeFromPath($path);
+        if ($mimeType === null) {
+            throw UnableToRetrieveMetadata::mimeType($path, 'Failed to determine MIME type from path');
+        }
+
         return new FileAttributes(
             $path,
             null,
             null,
             null,
-            $this->mimeTypeDetector->detectMimeTypeFromPath($path)
+            $mimeType
         );
     }
 

--- a/src/DropboxAdapter.php
+++ b/src/DropboxAdapter.php
@@ -188,8 +188,7 @@ class DropboxAdapter implements FilesystemAdapter, ChecksumProvider
      */
     public function visibility(string $path): FileAttributes
     {
-        // Noop
-        return new FileAttributes($path);
+        throw UnableToRetrieveMetadata::visibility($path, 'Adapter does not support visibility controls.');
     }
 
     /**

--- a/tests/DropboxAdapterTest.php
+++ b/tests/DropboxAdapterTest.php
@@ -6,6 +6,7 @@ use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToCreateDirectory;
 use League\Flysystem\UnableToMoveFile;
+use League\Flysystem\UnableToRetrieveMetadata;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -61,11 +62,15 @@ it('can work with meta date', function (string $method) {
         $this->dropboxAdapter->{$method}('one')
     );
 })->with([
-    'visibility',
+    // 'visibility', // Visibility is not supported
     'mimeType',
     'lastModified',
     'fileSize',
 ]);
+
+it('throws on retriving visibility', function () {
+    $this->dropboxAdapter->visibility('something');
+})->throws(UnableToRetrieveMetadata::class);
 
 it('can provide checksum', function (?string $algo, string $expected) {
     $this->client = $this->prophesize(Client::class);


### PR DESCRIPTION
⚠️ **BREAKING CHANGE**

The current implementation of the `visibility` method in the adapter returns an instance of `FileAttributes` with its `visibility` field set to `null` since visibility isn't supported. The problem is that Flysystem v3's `visibility` method's signature only allows for a `string` to be returned, not `null`. This causes a `TypeError: League\Flysystem\Filesystem::visibility(): Return value must be of type string, null returned`, when invoking the `visibility` method on a `Filesystem` instance that uses this adapter.

Although the changed code still aligns with the public API and documentation, this should be considered a breaking change. Previously, the visibility method **ALWAYS** returned a `FileAttributes` instance, but now it will **ALWAYS** throw an exception.

EDIT: I've also noticed an essentially identical problem with the `mimeType` method. The MIME type detector will return null in case it cannot determine the MIME Type. However, this causes a `TypeError` when called from the `Filesystem::mimeType` method, because it may only return a `string`.